### PR TITLE
Add z-index: 0 to elements with tooltip class and data-tooltip attrib…

### DIFF
--- a/assets/stylesheets/formir/components/tooltip.less
+++ b/assets/stylesheets/formir/components/tooltip.less
@@ -87,6 +87,7 @@
       .tooltip-core;
       content: attr(data-tooltip);
       display: block;
+      z-index: 0;
     }
     &:before {
       .tooltip-arrow-top;


### PR DESCRIPTION
…ute.

This is to hide tooltip under other elements with `position: relative`, such as navbars. 
